### PR TITLE
chore(user-list): make build fails on prettier lint errors

### DIFF
--- a/page-user-list/.eslintrc
+++ b/page-user-list/.eslintrc
@@ -3,5 +3,10 @@
   "extends": [
     "plugin:vue/essential",
     "@vue/prettier"
-  ]
+  ],
+  "rules": {
+    "prettier/prettier": [
+      "error"
+    ]
+  }
 }


### PR DESCRIPTION
Override vue-cli default eslint config to set prettier as lint errors