### PR TITLE
fix(layout) revert layou token

### DIFF
--- a/uid-pages/layout-living-application/src/resources/page.properties
+++ b/uid-pages/layout-living-application/src/resources/page.properties
@@ -1,7 +1,7 @@
 #The name must start with 'custompage_'
 #Mon Feb 25 17:37:11 CET 2019
-displayName=LivingApplicationLayoutPageV5
-name=custompage_LivingApplicationLayoutPageV5
+name=custompage_defaultlayout
+displayName=Default living application layout
 description=This is the default layout V5 definition for a newly-created application. It was created using the UI designer, so you can export it and edit it with the UI designer. It contains a horizontal menu widget and an iframe widget. The menu structure  is defined in the application navigation. The application pages are displayed in the iframe.
 resources=[GET|living/application, GET|living/application-menu, GET|living/application-page]
 contentType=layout


### PR DESCRIPTION
- revert layout page token to its original name so that there is no need to migrate applications that use the default layout

Covers [BPO-36](https://github.com/bonitasoft/bonita-web-pages/pull/117)