### PR TITLE
chore(build): update bonita plugins version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,15 @@
 plugins {
-    id 'com.bonitasoft.gradle.bonita-release' version '0.1.39'
+    id 'com.bonitasoft.gradle.bonita-release' version '0.1.42'
 }
 
 apply plugin: 'com.bonitasoft.gradle.bonita-uid'
 UIDesigner {
     version "1.8.36"
+}
+
+bonitaRelease {
+    // do not create a commit after the release (need to modify release.groovy to remove that)
+   createCommitAfter = false
 }
 
 allprojects {


### PR DESCRIPTION
added configuration to avoid creating commit after the release

this is to keep the previous behavior. in order to change that,
     release.groovy should be changed to checkout the tag before doing a
     publish