### PR TITLE
Fixing condition for hiding the archived case id

### DIFF
--- a/uid-pages/form-case-overview/src/caseoverview.json
+++ b/uid-pages/form-case-overview/src/caseoverview.json
@@ -3,7 +3,7 @@
   "previousDesignerVersion" : "1.8.29",
   "id" : "caseoverview",
   "name" : "caseoverview",
-  "lastUpdate" : 1562676236737,
+  "lastUpdate" : 1562830710076,
   "rows" : [ [ {
     "type" : "container",
     "dimension" : {
@@ -77,7 +77,7 @@
         },
         "hidden" : {
           "type" : "expression",
-          "value" : "!archivedContext"
+          "value" : "!archivedCase.length"
         },
         "text" : {
           "type" : "interpolation",


### PR DESCRIPTION
This needed to be applied since in Portal the archivedContext is still defined when it's an open case. The archivedCase is also defined, but it is empty.

Covers [BPO-170](https://bonitasoft.atlassian.net/browse/BPO-170)