### PR TITLE
chore(release): create a commit after the tag to be in SNAPSHOT again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,11 +10,6 @@ UIDesigner {
   version "1.10.47"
 }
 
-bonitaRelease {
-    // do not create a commit after the release (need to modify release.groovy to remove that)
-   createCommitAfter = false
-}
-
 allprojects {
     apply plugin: 'distribution'
     apply plugin: 'maven-publish'

--- a/infrastructure/buildVersion.groovy
+++ b/infrastructure/buildVersion.groovy
@@ -6,7 +6,7 @@ pipeline {
     stages {
         stage('Build and deploy') {
             steps {
-                sh("./gradlew clean build publish -x test -PaltDeploymentRepository=${ALT_DEPLOYMENT_REPOSITORY_TAG}")
+                sh("./gradlew clean publish -PaltDeploymentRepository=${ALT_DEPLOYMENT_REPOSITORY_TAG}")
             }
         }
     }


### PR DESCRIPTION
simply remove the gradle configuration to do that.

Also removed `build -x test` from publish. It is not usefull