### PR TITLE
chore(release): fix script that build a version

### DIFF
--- a/infrastructure/buildVersion.groovy
+++ b/infrastructure/buildVersion.groovy
@@ -6,7 +6,7 @@ pipeline {
     stages {
         stage('Build and deploy') {
             steps {
-                sh("./gradlew clean publish -PaltDeploymentRepository=${ALT_DEPLOYMENT_REPOSITORY_TAG}")
+                sh("./gradlew clean build publish -x test -PaltDeploymentRepository=${ALT_DEPLOYMENT_REPOSITORY_TAG}")
             }
         }
     }


### PR DESCRIPTION
due to a missing dependency in tasks, publish does not construct
artifacts

```
Invalid publication 'zip': artifact file does not exist: '/home/jenkins/workspace/release/bonita/binaries/web-pages/uid-pages/form-case-overview/build/form-case-overview-7.10.3.zip
```