### PR TITLE
fix(layout) language selection with locale in URL

### DIFF
--- a/uid-pages/layout-bonita/src/LayoutBonitaV6.json
+++ b/uid-pages/layout-bonita/src/LayoutBonitaV6.json
@@ -3,7 +3,7 @@
   "previousArtifactVersion" : "1.10.18",
   "id" : "LayoutBonitaV6",
   "name" : "BonitaLayoutV6",
-  "lastUpdate" : 1603442966380,
+  "lastUpdate" : 1605528073401,
   "rows" : [
     [
       {
@@ -2594,8 +2594,15 @@
         "if($data.eventList.actions && $data.eventList.actions.length > 0){",
         "    var action=$data.eventList.actions[0];",
         "    if(action===\"locale\"){",
-        "        document.cookie=\"BOS_Locale=\"+$data.selectedLanguage.locale+\";path=/\";;",
-        "        document.location.reload();",
+        "        document.cookie=\"BOS_Locale=\"+$data.selectedLanguage.locale+\";path=/\";",
+        "        try {",
+        "            var url = new URL(document.location.href);",
+        "            url.searchParams.delete('locale');",
+        "            url.searchParams.delete('_l');",
+        "            document.location.assign(url.href);",
+        "        } catch (error) {",
+        "            document.location.reload();",
+        "        }",
         "    }",
         "}"
       ],

--- a/uid-pages/layout-bonita/step_definitions/layoutBonita.js
+++ b/uid-pages/layout-bonita/step_definitions/layoutBonita.js
@@ -248,6 +248,11 @@ when('I visit the index page', () => {
     cy.wait('@app1Route');
 });
 
+when('I visit the index page with a parameter {string} in the URL', (localeParamName) => {
+    cy.visit(url + '?' + localeParamName + '=es');
+    cy.wait('@app1Route');
+});
+
 when('I click the user name', () => {
     cy.get('.text-right > .ng-binding').click();
 });
@@ -329,6 +334,10 @@ when('I click next to the current session modal', () => {
 
 then( 'The application displayName is {string}', (appName) => {
     cy.get('pb-link > .text-left > .ng-binding').should('have.text', appName);
+});
+
+when('I click on the appName', () => {
+    cy.get('.navbar-brand').click();
 });
 
 then('The {string} page displayName is {string}', (pageNumber, pageName) => {
@@ -429,6 +438,14 @@ then('The apply button is enabled', () => {
 
 then('The language in BOS_Locale is {string}', (languageSelected) => {
     cy.getCookie('BOS_Locale').should('have.property', 'value', languageSelected);
+});
+
+then('The parameter {string} is not in the URL', (parameterName) => {
+    cy.url().should('not.include', parameterName + '=');
+});
+
+then('The parameter {string} is in the URL', (parameterName) => {
+    cy.url().should('include', parameterName + '=');
 });
 
 then('The current session modal is not visible', () => {
@@ -611,10 +628,6 @@ then('Application name has {string} as application href', (homePageHref) => {
     cy.get('.app-title a').should('have.attr', 'href', homePageHref);
 });
 
-when('I click on the appName', () => {
-    cy.get('.navbar-brand').click();
-});
-
 then('Application name has {string} as application href in mobile view', (homePageHref) => {
     cy.url().should('include', homePageHref);
 });
@@ -638,4 +651,9 @@ then('The current language is {string}', (language) => {
             cy.get('select').should('have.value','3');
             break;
     }
+});
+
+then('Page reloads', () => {
+    //necessary when the page reloads to avoid modale opening failure
+    cy.reload();
 });

--- a/uid-pages/layout-bonita/test/specs/layoutSessionModalDesktop.feature
+++ b/uid-pages/layout-bonita/test/specs/layoutSessionModalDesktop.feature
@@ -62,6 +62,22 @@ Feature: The Bonita layout current session modal in desktop resolution
     Then The apply button is enabled
     When I press the apply button
     Then The language in BOS_Locale is "fr"
+    Then Page reloads
+    
+  Scenario: The language is changed in current session modal when locale is set in URL
+    Given The URL target to the application "appName1"
+    And A user is connected without sso
+    And The user has a first and last name defined
+    And I have languages available
+    When I visit the index page with a parameter "locale" in the URL
+    And I click the user name
+    Then The current session modal is visible
+    And The parameter "locale" is in the URL
+    When I select "Français" in language picker
+    When I press the apply button
+    Then The language in BOS_Locale is "fr"
+    Then The parameter "locale" is not in the URL
+    Then Page reloads
 
   Scenario: The current session modal closes correctly
     Given The URL target to the application "appName1"


### PR DESCRIPTION
- remove locale parameter from URL when selecting language
- use new [URLSearchparams API](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/delete) since IE 11 is no longer supported

Covers [BR-582](https://bonitasoft.atlassian.net/browse/BR-582)