### PR TITLE
chore(rebranding): update bonitasoft.com domain references to ofelia.com

### DIFF
--- a/infrastructure/contributing.md
+++ b/infrastructure/contributing.md
@@ -97,6 +97,6 @@ Closes [BS-14965](https://bonitasoft.atlassian.net/browse/BS-14965)
 
 # Additional Resources
 
-* [Community website](http://community.ofelia.com/)
+* [Community website](https://community.ofelia.com/blog)
 * [Community Bug tracker (Jira)](https://bonita.atlassian.net/projects/BBPMC/)
 * [Internal Bug tracker (Jira)](https://bonitasoft.atlassian.net/projects/BS/)

--- a/other-pages/bootstrap-default-theme/test/index.html
+++ b/other-pages/bootstrap-default-theme/test/index.html
@@ -35,7 +35,7 @@
               <a href="../help/">Help</a>
             </li>
             <li>
-              <a href="https://community.bonitasoft.com/blog">Blog</a>
+              <a href="https://community.ofelia.com/blog">Blog</a>
             </li>
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="download">Download <span class="caret"></span></a>
@@ -1225,7 +1225,7 @@
 
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
-              <li><a href="https://community.bonitasoft.com/blog">Blog</a></li>
+              <li><a href="https://community.ofelia.com/blog">Blog</a></li>
               <li><a href="https://twitter.com/bonitasoft">Twitter</a></li>
               <li><a href="https://github.com/bonitasoft/">GitHub</a></li>
             </ul>


### PR DESCRIPTION
Replace bonitasoft.com domain URLs with ofelia.com equivalents. No logic changes. Part of the Bonitasoft → Ofelia rebranding.